### PR TITLE
Adds --force-[no-]bootstrap rule for "ript rules generate".

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,15 @@ sudo bin/rbenv-sudo cucumber -r features/support/ -r features/step_definitions/ 
 
 ript commands can be run like so:
 
-```` bash
+``` bash
 sudo bin/rbenv-sudo bundle exec ript --help
+```
+
+Outside of this environment, rules can be generated (for debugging purposes) by forcing the inclusion or the exclusion of the bootstrap rules. These can be run as a non-root user.
+
+```bash
+bundle exec ript rules generate examples/basic.rb --force-bootstrap    # Includes the ript/bootstrap rules, or...
+bundle exec ript rules generate examples/basic.rb --force-no-bootstrap # Exclude the ript/bootstrap rules
 ```
 
 Releasing

--- a/bin/ript
+++ b/bin/ript
@@ -7,20 +7,43 @@ $: << Pathname.new(__FILE__).parent.parent.expand_path.to_s
 $: << Dir.pwd
 require 'ript/dsl'
 require 'tempfile'
+require 'optparse'
 
 if RUBY_VERSION =~ /^1.8/ then
   puts "Ript requires Ruby 1.9 to run. Exiting."
   exit
 end
 
-if Process.uid != 0 then
-  puts "You must run this as root!"
-  exit 1
-end
-
 if not ARGV[0]
   puts "Usage: #{$0} <rulefile|directory>"
   exit! 1
+end
+
+def require_root!
+  if Process.uid != 0 then
+    puts "You must run this as root!"
+    exit 1
+  end
+end
+
+def bootstrap_strategy(argv=ARGV)
+  strategy = :detect
+  parser = OptionParser.new do |opts|
+    opts.on('--force-bootstrap', 'Force inclusion of the ript/bootstrap rules') do |f|
+      strategy = :force_include
+    end
+    opts.on('--force-no-bootstrap', 'Force exclusion of the ript/bootstrap rules') do |f|
+      strategy = :force_exclude
+    end
+  end
+  parser.parse!(argv)
+  strategy
+end
+
+def include_bootstrap
+  require 'ript/bootstrap'
+  puts "# bootstrap"
+  puts Ript::Bootstrap.partition.to_iptables
 end
 
 def types
@@ -92,10 +115,14 @@ if ARGV[0] == 'rules'
       exit 160
     end
 
-    if `iptables --list partition-a --numeric 2>&1 | grep Chain` !~ /^Chain/
-      require 'ript/bootstrap'
-      puts "# bootstrap"
-      puts Ript::Bootstrap.partition.to_iptables
+    case bootstrap_strategy
+    when :force_include
+      include_bootstrap
+    when :detect
+      require_root!
+      if `iptables --list partition-a --numeric 2>&1 | grep Chain` !~ /^Chain/
+        include_bootstrap
+      end
     end
 
     if ARGV[1] == "generate"
@@ -106,6 +133,7 @@ if ARGV[0] == 'rules'
     end
 
     if ARGV[1] == "diff"
+      require_root!
       @partitions.each do |partition|
         # We assume here that if a partition has a partition-a chain it will have all the others
         chain_name = "#{partition.name}-#{partition.id.split('-').first}".sub(/-/, '-a')
@@ -120,6 +148,7 @@ if ARGV[0] == 'rules'
   end
 
   if ARGV[1] == "apply" then
+    require_root!
     output   = `#{$0} rules diff #{ARGV[2..-1].join(' ')} 2>&1`
     tempfile = Tempfile.open("ript-apply-#{Time.now.to_i}") {|f| f << output}
     puts "#{output}"
@@ -128,6 +157,7 @@ if ARGV[0] == 'rules'
   end
 
   if ARGV[1] == 'flush' then
+    require_root!
     output = <<-EOF
   iptables --flush --table filter
   iptables --delete-chain --table filter
@@ -158,6 +188,7 @@ if ARGV[0] == 'rules'
   end
 
   if ARGV[1] == 'save' then
+    require_root!
     system('/sbin/iptables-save')
     exit
   end
@@ -167,6 +198,7 @@ if ARGV[0] == 'rules'
 end
 
 if ARGV[0] == "clean" then
+  require_root!
   if ARGV[1] == "diff" then
     path = Pathname.new(ARGV[2])
 

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -142,3 +142,32 @@ Feature: Ript cli utility
         iptables --table mangle --policy FORWARD ACCEPT
         iptables --table mangle --policy OUTPUT ACCEPT
       """
+
+  @sudo @timeout-10
+  Scenario: Bootstrap forced inclusion, exclusion, detection
+    Given I have no iptables rules loaded
+    When I run `ript rules generate examples/basic.rb --force-bootstrap`
+    Then the output from "ript rules generate examples/basic.rb --force-bootstrap" should match:
+      """
+      # bootstrap
+      iptables --table nat --new-chain ript_bootstrap-.*
+      """
+    And the output from "ript rules generate examples/basic.rb --force-bootstrap" should match:
+      """
+      iptables --table nat --new-chain basic-d\w+
+      iptables --table nat --new-chain basic-s\w+
+      iptables --table filter --new-chain basic-a\w+
+      """
+
+    When I run `ript rules generate examples/basic.rb --force-no-bootstrap`
+    Then the output from "ript rules generate examples/basic.rb --force-no-bootstrap" should not match:
+      """
+      # bootstrap
+      iptables --table nat --new-chain ript_bootstrap-.*
+      """
+    And the output from "ript rules generate examples/basic.rb --force-no-bootstrap" should match:
+      """
+      iptables --table nat --new-chain basic-d\w+
+      iptables --table nat --new-chain basic-s\w+
+      iptables --table filter --new-chain basic-a\w+
+      """

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -6,6 +6,10 @@ Then /^the output from "([^"]*)" should match:$/ do |cmd, partial_output|
   output_from(cmd).should =~ /#{partial_output}/
 end
 
+Then /^the output from "([^"]*)" should not match:$/ do |cmd, partial_output|
+  output_from(cmd).should_not =~ /#{partial_output}/
+end
+
 Then /^the output from "([^"]*)" should contain exactly:$/ do |cmd, exact_output|
   output_from(cmd).should == exact_output
 end


### PR DESCRIPTION
Fixes #9 by moving the root-only restriction into the actions that need it.

Tested with `rake features` running inside an Ubuntu 12.04 VM; until https://github.com/travis-ci/travis-ci/issues/1341 is fixed it looks like a Travis build won't be possible.

(I have [another branch](https://github.com/damncabbage/ript/compare/bulletproofnetworks:master...damncabbage:globals) that starts to move chunks of `bin/ript` out to `lib/ript/iptables.rb` and `lib/ript/cli.rb`, but this is a minimal change to get #9 in without rearranging everything; the refactoring can follow if necessary.)
